### PR TITLE
Fix the missing window icon when running under Wayland

### DIFF
--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -46,6 +46,7 @@ int main(int argc, char *argv[])
     }
 
     QApplication a(argc, argv);
+    a.setDesktopFileName("xelfviewer");
     // TODO set main image
 
     XOptions xOptions;

--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -46,7 +46,11 @@ int main(int argc, char *argv[])
     }
 
     QApplication a(argc, argv);
+
+#ifdef Q_OS_LINUX
     a.setDesktopFileName("xelfviewer");
+#endif
+
     // TODO set main image
 
     XOptions xOptions;


### PR DESCRIPTION
Currently, when running under Wayland, the window icon will fallback to the default Wayland icon.
Setting the desktop filename can solve this problem.
Similar to https://github.com/horsicq/XAPKDetector/pull/9